### PR TITLE
Remove the reccomendation to turn down graphics quality to prevent crashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
             <p>Your system doesn't have Desktop Portals properly configured. You can <a href="https://wiki.archlinux.org/title/XDG_Desktop_Portal">read documentation online</a> for information on how to fix this. Alternatively, you can download the Flatseal app and temporarily give Sober access to your Downloads directory.</p>
 
             <h4 id="how-does-sober-work" class="h4">Why does Sober keep crashing?</h4>
-            <p>Sober is experimental software, so expect crashes. To help us fix the issue, try to provide logs by running Sober from the terminal: <code>flatpak run org.vinegarhq.Sober</code>. Note that high graphics quality levels are known to be unstable. If you're having consistent crashes, turning down the graphics quality in Roblox's settings might help.</p>
+            <p>Sober is experimental software, so expect crashes. To help us fix the issue, try to provide logs by running Sober from the terminal: <code>flatpak run org.vinegarhq.Sober</code></p>
 
             <h4 id="is-it-official" class="h4">Is Sober official? Will it get blocked by Roblox?</h4>
             <p>Sober is not affiliated with Roblox in any way. It's an unofficial community-made experimental project. Roblox may choose to prevent the Sober client from using their services.</p>


### PR DESCRIPTION
As far as I know, turning down graphics quality isn't really known to prevent crashes anymore