### PR TITLE
Append README with notice for out-of-date clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Not affiliated with Roblox.
 
 This GitHub repository serves as a issue tracker for bugs or feature suggestions.
 
+> Please refrain from opening issues for out-of-date clients. The Sober team is aware and will push an update as soon as possible.
+
 See [sober.vinegarhq.org](https://sober.vinegarhq.org) for more information.


### PR DESCRIPTION
Unhelpful issues and duplicates are created every time the client is out of date.

Unless these issues actually help the Sober team (which I heavily doubt; I would assume you use Sober yourselves, right?), maybe an addendum to the README would help reduce the volume of these issues. The bug issue template checkbox clearly isn't helping.