### PR TITLE
add documentation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,10 @@
         <span class="heading">Roblox, better than ever on Linux</span>
         <span class="desc">We're testing Sober, an unofficial port of Roblox to Linux.<br>No emulators or virtual
             machines. Up to twice the performance of native Windows.</span>
-        <a href="#introducing-sober" class="Button filled">Learn More -></a>
+        <span>
+            <a href="#introducing-sober" class="Button filled">Learn More -></a>
+            <a href="https://vinegarhq.org/Sober/Home/index.html" class="Button filled">Documentation &#x2197;</a>
+        </span>
     </section>
 
     <section class="Card text">


### PR DESCRIPTION
since sober documentation is available under vinegarhq.org it would make sense to add a link to it
(unless the "more in-depth website experience" is being created right now)

![Screenshot from 2025-03-26 22-24-27](https://github.com/user-attachments/assets/9622702b-7c73-49b0-ad41-93772e56f2bc)
