### PR TITLE
add flathub installation method

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,9 +67,14 @@
     <section class="Card">
         <div class="Card text">
             <h2 id="installing" class="h2">Installing</h2>
-
             <p>
-                We distribute Sober as a Flatpak package. Here's how to use it:
+                Sober is available to download on <a href="https://flathub.org/apps/org.vinegarhq.Sober">Flathub</a>.
+            </p>
+            <a href="https://flathub.org/apps/org.vinegarhq.Sober">
+                <img alt="Download on Flathub" src="https://dl.flathub.org/assets/badges/flathub-badge-en.png"/>
+            </a>
+            <p>
+                We also distribute Sober as a Flatpak package. Here's how to use it:
             </p>
             <ol class="instructions">
                 <li>


### PR DESCRIPTION
not sure if the original installation method will stick around
the badge size may need to be changed
![webpage reference](https://github.com/user-attachments/assets/ef5c16b3-ec81-4e7f-8181-de674e818e6b)
